### PR TITLE
Update mod_form.php

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -67,7 +67,14 @@ class mod_courseboard_mod_form extends moodleform_mod {
             $mform->addRule('name', get_string('maximumchars', '', 255), 'maxlength', 255, 'client');
 
         // Adding the required 'intro' field to hold the description of the instance.
-           $this->add_intro_editor(true, get_string('intro', 'courseboard'));
+			if (version_compare(moodle_major_version(true), '2.9', '>='))
+			{
+				$this->standard_intro_elements();
+			}
+			else
+			{
+				$this->add_intro_editor(true, get_string('intro', 'courseboard'));
+			}
 
             // Add standard elements, common to all modules.
                 $features = new object();


### PR DESCRIPTION
Make it upward compatible to Moodle 2.9+ without loosing compatibility to version of Moodle 2.8.x and lower. So it can be released for Moodle 2.9.

As it is also runnig stable under Moodle 2.6, please also release it for this version as tis is still under long term support. ;-)

Thank you.
